### PR TITLE
Move video decoder state to ResourceVideoMedia

### DIFF
--- a/FramePFX/Render/OGL/OGLRenderContext.cs
+++ b/FramePFX/Render/OGL/OGLRenderContext.cs
@@ -47,16 +47,6 @@ namespace FramePFX.Render.OGL {
             GL.Viewport(0, 0, width, height);
             OGLUtils.SetOrthoMatrix(width, height);
 
-            GL.DebugMessageCallback((source, type, id, severity, length, ptext, _) => {
-                string severityStr = severity.ToString().Substring("DebugSeverity".Length).ToUpper();
-                string sourceStr = source.ToString().Substring("DebugSource".Length);
-                string typeStr = type.ToString().Substring("DebugType".Length);
-                string text = Marshal.PtrToStringAnsi(ptext);
-
-                Console.WriteLine($"GL-{sourceStr}-{typeStr}: [{severityStr}] {text}");
-            }, IntPtr.Zero);
-            GL.Enable(EnableCap.DebugOutput);
-
             // Fix OpenGL flipped image
             // GL.Rotate(180, 0, 0, 1);
             // GL.Scale(-1f, 1f, 1f);

--- a/FramePFX/ResourceManaging/Items/ResourceVideoMedia.cs
+++ b/FramePFX/ResourceManaging/Items/ResourceVideoMedia.cs
@@ -23,17 +23,6 @@ namespace FramePFX.ResourceManaging.Items {
         private VideoDecoder decoder;
         private FrameQueue frameQueue;
 
-        private void ReopenDemuxer() {
-            try {
-                this.ReleaseDecoder();
-                this.Demuxer = new MediaDemuxer(this.FilePath);
-                this.stream = this.Demuxer.FindBestStream(MediaTypes.Video);
-            }
-            catch {
-                //Invalid media file
-            }
-        }
-
         public unsafe Resolution GetResolution() {
             if (this.HasVideoStream) {
                 //Wrappers don't expose this stuff so :') 
@@ -42,6 +31,7 @@ namespace FramePFX.ResourceManaging.Items {
             }
             return default;
         }
+
         public TimeSpan GetDuration() {
             return this.Demuxer.Duration ?? TimeSpan.Zero;
         }
@@ -55,9 +45,8 @@ namespace FramePFX.ResourceManaging.Items {
             }
 
             //Images have a single frame, which we'll miss if we don't clamp timestamp to zero.
-            TimeSpan duration = this.Demuxer.Duration ?? TimeSpan.Zero;
-            if (timestamp > duration) {
-                timestamp = duration;
+            if (timestamp > this.GetDuration()) {
+                timestamp = this.GetDuration();
             }
 
             VideoFrame frame = this.frameQueue.GetNearest(timestamp, out double frameDist);
@@ -102,6 +91,17 @@ namespace FramePFX.ResourceManaging.Items {
                         return false;
                     }
                 }
+            }
+        }
+
+        private void ReopenDemuxer() {
+            try {
+                this.ReleaseDecoder();
+                this.Demuxer = new MediaDemuxer(this.FilePath);
+                this.stream = this.Demuxer.FindBestStream(MediaTypes.Video);
+            }
+            catch {
+                //Invalid media file
             }
         }
 

--- a/FramePFX/ResourceManaging/Items/ResourceVideoMedia.cs
+++ b/FramePFX/ResourceManaging/Items/ResourceVideoMedia.cs
@@ -1,18 +1,207 @@
+using System;
+using FFmpeg.AutoGen;
 using FFmpeg.Wrapper;
+using FramePFX.Core.Utils;
 
 namespace FramePFX.ResourceManaging.Items {
     public class ResourceVideoMedia : ResourceItem {
         private string filePath;
         public string FilePath {
             get => this.filePath;
-            set => this.RaisePropertyChanged(ref this.filePath, value);
+            set {
+                this.RaisePropertyChanged(ref this.filePath, value);
+                this.ReopenDemuxer(); //TODO: is this the proper way?
+            }
         }
 
-        // TODO: Somehow process video frames here, and provide frame caching maybe?
         public MediaDemuxer Demuxer { get; private set; }
 
-        public override void DisposeResource() {
+        public bool IsValidMediaFile => this.Demuxer != null;
+        public bool HasVideoStream => this.stream != null;
+
+        private MediaStream stream;
+        private VideoDecoder decoder;
+        private FrameQueue frameQueue;
+
+        private void ReopenDemuxer() {
+            try {
+                this.ReleaseDecoder();
+                this.Demuxer = new MediaDemuxer(this.FilePath);
+                this.stream = this.Demuxer.FindBestStream(MediaTypes.Video);
+            }
+            catch {
+                //Invalid media file
+            }
+        }
+
+        public unsafe Resolution GetResolution() {
+            if (this.HasVideoStream) {
+                //Wrappers don't expose this stuff so :') 
+                AVCodecParameters* pars = this.stream.Handle->codecpar;
+                return new Resolution(pars->width, pars->height);
+            }
+            return default;
+        }
+        public TimeSpan GetDuration() {
+            return this.Demuxer.Duration ?? TimeSpan.Zero;
+        }
+
+        public VideoFrame GetFrameAt(TimeSpan timestamp) {
+            if (!this.HasVideoStream) {
+                return null;
+            }
+            if (this.decoder == null) {
+                this.OpenDecoder();
+            }
+
+            //Images have a single frame, which we'll miss if we don't clamp timestamp to zero.
+            TimeSpan duration = this.Demuxer.Duration ?? TimeSpan.Zero;
+            if (timestamp > duration) {
+                timestamp = duration;
+            }
+
+            VideoFrame frame = this.frameQueue.GetNearest(timestamp, out double frameDist);
+            double distThreshold = 0.5 / this.stream.AvgFrameRate; //will dupe too many frames if set to 1.0
+
+            if (Math.Abs(frameDist) > distThreshold) {
+                //If the nearest frame is past or too far after the requested timestamp, seek to the nearest keyframe before it
+                if (frameDist < 0 || frameDist > 5.0) {
+                    this.Demuxer.Seek(timestamp);
+                    this.decoder.Flush();
+                }
+                this.DecodeFramesUntil(timestamp);
+
+                frame = this.frameQueue.GetNearest(timestamp, out _);
+            }
+            return frame;
+        }
+
+        private bool DecodeFramesUntil(TimeSpan endTime) {
+            while (true) {
+                VideoFrame frame = this.frameQueue.Reserve();
+
+                if (this.decoder.ReceiveFrame(frame)) {
+                    if (this.frameQueue.Shift() >= endTime) {
+                        return true;
+                    }
+                }
+
+                //Fill-up the decoder with more data and try again
+                using (var packet = new MediaPacket()) {
+                    bool gotPacket = false;
+
+                    while (this.Demuxer.Read(packet)) {
+                        if (packet.StreamIndex == this.stream.Index) {
+                            this.decoder.SendPacket(packet);
+                            gotPacket = true;
+                            break;
+                        }
+                    }
+                    if (!gotPacket) {
+                        //Reached the end of the file
+                        return false;
+                    }
+                }
+            }
+        }
+
+        private void OpenDecoder() {
+            this.decoder = (VideoDecoder) this.Demuxer.CreateStreamDecoder(this.stream, open: false);
+            this.frameQueue = new FrameQueue(this.stream, 2);
+
+            this.TrySetupHardwareDecoder();
+            this.decoder.Open();
+        }
+
+        private void TrySetupHardwareDecoder() {
+            if (this.decoder.PixelFormat != AVPixelFormat.AV_PIX_FMT_YUV420P &&
+                this.decoder.PixelFormat != AVPixelFormat.AV_PIX_FMT_YUV420P10LE
+            ) {
+                //TODO: SetupHardwareAccelerator() will return NONE from get_format() rather than fallback to sw formats,
+                //      causing SendPacket() to throw with InvalidData for sources with unsupported hw pixel formats like YUV444.
+                return;
+            }
+
+            foreach (CodecHardwareConfig config in this.decoder.GetHardwareConfigs()) {
+                using (var device = HardwareDevice.Create(config.DeviceType)) {
+                    if (device != null) {
+                        this.decoder.SetupHardwareAccelerator(device, config.PixelFormat);
+                        break;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Deallocates media decoders and internal frames.
+        /// </summary>
+        public void ReleaseDecoder() {
+            this.decoder?.Dispose();
+            this.decoder = null;
+
+            this.frameQueue?.Dispose();
+            this.frameQueue = null;
+        }
+
+        protected override void DisposeResource() {
+            base.DisposeResource();
+            this.ReleaseDecoder();
+
             this.Demuxer?.Dispose();
+            this.Demuxer = null;
+        }
+
+        //Rolling circular-buffer of `VideoFrame`s
+        private class FrameQueue : IDisposable {
+            private readonly MediaStream stream;
+            private readonly VideoFrame[] frames;
+            private int index = 0;
+
+            public FrameQueue(MediaStream stream, int size) {
+                this.stream = stream;
+                this.frames = new VideoFrame[size];
+
+                for (int i = 0; i < size; i++) {
+                    this.frames[i] = new VideoFrame();
+                }
+            }
+
+            public VideoFrame Reserve() {
+                return this.frames[this.index % this.frames.Length];
+            }
+
+            public TimeSpan Shift() {
+                VideoFrame lastFrame = this.Reserve();
+                this.index++;
+                return this.GetTime(lastFrame);
+            }
+
+            public TimeSpan GetTime(VideoFrame frame) {
+                return this.stream.GetTimestamp(frame.PresentationTimestamp.Value);
+            }
+
+            public VideoFrame GetNearest(TimeSpan timestamp, out double nearestDist) {
+                VideoFrame nearestFrame = null;
+                nearestDist = double.PositiveInfinity;
+
+                foreach (VideoFrame frame in this.frames) {
+                    if (frame.PresentationTimestamp == null) continue;
+
+                    double dist = (timestamp - this.GetTime(frame)).TotalSeconds;
+
+                    if (Math.Abs(dist) < Math.Abs(nearestDist)) {
+                        nearestFrame = frame;
+                        nearestDist = dist;
+                    }
+                }
+                return nearestFrame;
+            }
+
+            public void Dispose() {
+                for (int i = 0; i < this.frames.Length; i++) {
+                    this.frames[i].Dispose();
+                }
+            }
         }
     }
 }

--- a/FramePFX/ResourceManaging/ResourceItem.cs
+++ b/FramePFX/ResourceManaging/ResourceItem.cs
@@ -91,7 +91,7 @@ namespace FramePFX.ResourceManaging {
             }
         }
 
-        public virtual void DisposeResource() {
+        protected virtual void DisposeResource() {
 
         }
 

--- a/FramePFX/ResourceManaging/ResourceManager.cs
+++ b/FramePFX/ResourceManaging/ResourceManager.cs
@@ -177,12 +177,13 @@ namespace FramePFX.ResourceManaging {
         }
 
         public ResourceItem AddFile(string file) {
-            if (!File.Exists(file)) {
+            ResourceVideoMedia resource = new ResourceVideoMedia {
+                FilePath = file
+            };
+            if (!resource.IsValidMediaFile) {
+                resource.Dispose();
                 return null;
             }
-            //TODO: ffmpeg can handle pretty much any format ever, but we should validate the file before returning the resource
-            ResourceVideoMedia resource = new ResourceVideoMedia();
-            resource.FilePath = file;
             this.AddResource(this.GenerateUniqueIdForFile(file), resource);
             return resource;
         }

--- a/FramePFX/ViewportPlayback.cs
+++ b/FramePFX/ViewportPlayback.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Windows.Input;
@@ -105,7 +106,7 @@ namespace FramePFX {
                     if (time >= this.nextPlaybackTick) { //  || (time + 1) >= this.nextPlaybackTick // time + 1 for ahead of time playback... just in case
                         this.playbackAverageIntervalMS.PushValue(time - this.lastPlaybackTick);
                         this.lastPlaybackTick = time;
-                        this.nextPlaybackTick = time + 33L; // 33ms = 30fps
+                        this.nextPlaybackTick = time + (int) Math.Round(1000.0 / this.Editor.ActiveProject.PlaybackFPS);
                         timeline.StepFrame();
                         if (timeline.IsRenderDirty) {
                             this.RenderTimeline(timeline);


### PR DESCRIPTION
Instead of allocating a demuxer and decoder state for each clip, share them per resource to reduce memory usage. This will be slower for edge cases like overlapping clips with the same source, but I think that'd be a relatively rare scenario.

This also fixes the frame hiccup bug that existed before via a frame queue/buffer (which is a bit overkill but could turn to be useful later). It basically duplicates or drops frames to the nearest timestamp, so there are still some artifacts but they're less noticeable than before.

I'm not sure if it's okay to open the demuxer on the FilePath setter and nested inner classes, so let me know if you have any suggestions.